### PR TITLE
add _setCollateralPaused()

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -724,7 +724,7 @@ contract Comptroller is ComptrollerV6Storage, ComptrollerInterface, ComptrollerE
             
             // New code
             // Check if the collateral is paused, only for borrowing
-            if (collateralGuardianPaused[address(asset)] == true && borrowAmount>0){
+            if (collateralGuardianPaused[address(asset)] == true && borrowAmount > 0 && vars.cTokenBalance > 0){
                 return (Error.COLLATERAL_PAUSED, 0, 0);
             }
 

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -143,3 +143,17 @@ contract ComptrollerV5Storage is ComptrollerV4Storage {
     /// @notice Last block at which a contributor's COMP rewards have been allocated
     mapping(address => uint) public lastContributorBlock;
 }
+
+//New code
+contract ComptrollerV6Storage is ComptrollerV5Storage {
+
+    /** 
+     * @notice Addition to the Pause Guardian storage slots in V2. 
+     * Appended as V6 to avoid introducing storage slot conflicts.
+     */
+
+
+    /// @notice Whether a cToken is paused for borrowing or not
+    mapping(address => bool) public collateralGuardianPaused; 
+}
+

--- a/contracts/ErrorReporter.sol
+++ b/contracts/ErrorReporter.sol
@@ -19,7 +19,8 @@ contract ComptrollerErrorReporter {
         REJECTION,
         SNAPSHOT_ERROR,
         TOO_MANY_ASSETS,
-        TOO_MUCH_REPAY
+        TOO_MUCH_REPAY,
+        COLLATERAL_PAUSED
     }
 
     enum FailureInfo {


### PR DESCRIPTION
Summary:
Comptroller.sol: added _setCollateralPaused() and changed getHypotheticalAccountLiquidityInternal() to reflect new error
ErrorReporter.sol: added new COLLATERAL_PAUSED error for the comptroller
ComptrollerStorage.sol: added V6 to store collateralGuardianPaused state